### PR TITLE
Admin order

### DIFF
--- a/app/controllers/admins/homes_controller.rb
+++ b/app/controllers/admins/homes_controller.rb
@@ -1,13 +1,13 @@
 class Admins::HomesController < ApplicationController
   def top
-    # うまくいかないのでいったんコメントアウトしてます。
-    # if session[:orders]
-    #   @orders = session[:orders].page(params[:page]).per(10)
-    # else
-    #   @orders = Order.page(params[:page]).per(10)
-    # end
-# 仮
-    @orders = Order.page(params[:page]).per(10)
-    @order = Order.new
+    # 前ページのデータを引くための記述
+    path = Rails.application.routes.recognize_path(request.referer)
+
+    # 転移元のリンクに引数を渡すことで、どのリンクから飛んだか条件分岐している
+    if params[:order_sort] == "0"
+      @orders = Order.page(params[:page]).per(10)
+    else
+      @orders = Order.where(customer_id: path[:id]).page(params[:page]).per(10)
+    end
   end
 end

--- a/app/controllers/admins/homes_controller.rb
+++ b/app/controllers/admins/homes_controller.rb
@@ -5,9 +5,9 @@ class Admins::HomesController < ApplicationController
 
     # 転移元のリンクに引数を渡すことで、どのリンクから飛んだか条件分岐している
     if params[:order_sort] == "0"
-      @orders = Order.page(params[:page]).per(10)
-    else
       @orders = Order.where(customer_id: path[:id]).page(params[:page]).per(10)
+    else
+      @orders = Order.page(params[:page]).per(10)
     end
   end
 end

--- a/app/controllers/admins/order_items_controller.rb
+++ b/app/controllers/admins/order_items_controller.rb
@@ -1,7 +1,7 @@
 class Admins::OrderItemsController < ApplicationController
   def update
     order_item = OrderItem.find(params[:id])
-    order_item.update(production_status: params[:production_status].to_i)
+    order_item.update(order_item_params)
     redirect_back(fallback_location: root_path)
   end
 

--- a/app/controllers/admins/order_items_controller.rb
+++ b/app/controllers/admins/order_items_controller.rb
@@ -1,2 +1,12 @@
 class Admins::OrderItemsController < ApplicationController
+  def update
+    order_item = OrderItem.find(params[:id])
+    order_item.update(production_status: params[:production_status].to_i)
+    redirect_back(fallback_location: root_path)
+  end
+
+  private
+  def order_item_params
+    params.require(:order_item).permit(:production_status)
+  end
 end

--- a/app/controllers/admins/orders_controller.rb
+++ b/app/controllers/admins/orders_controller.rb
@@ -2,13 +2,13 @@ class Admins::OrdersController < ApplicationController
   def show
     @order = Order.find(params[:id])
     @order_items = @order.order_items
-    session[:orders] = Order.find(params[:id]).customer.orders
+    # session[:orders] = Order.find(params[:id]).customer.orders
   end
 
   def update
     order = Order.find(params[:id])
     # binding.pry
-    order.update(order_status: params[:order_status].to_i)
+    order.update(order_params)
     redirect_back(fallback_location: root_path)
   end
 
@@ -22,6 +22,5 @@ class Admins::OrdersController < ApplicationController
   def order_params
     params.require(:order).permit(:customer_id, :delivery_zip_code, :delivery_address, :delivery_name, :total_price, :shipping_price, :billing_amount, :payment_method, :order_status)
   end
-# ここまで
 
 end

--- a/app/controllers/admins/orders_controller.rb
+++ b/app/controllers/admins/orders_controller.rb
@@ -6,9 +6,12 @@ class Admins::OrdersController < ApplicationController
   end
 
   def update
+    order = Order.find(params[:id])
+    # binding.pry
+    order.update(order_status: params[:order_status].to_i)
+    redirect_back(fallback_location: root_path)
   end
 
-# 仮
   def create
     @order = Order.new(order_params)
     @order.save

--- a/app/views/admins/customers/show.html.erb
+++ b/app/views/admins/customers/show.html.erb
@@ -53,6 +53,6 @@
 
     <div class="col-md-10 text-center">
         <%= link_to "編集する", edit_admins_customer_path(@customer), class: 'btn btn-success form' %>
-        <%= link_to "注文履歴一覧を見る", admins_homes_top_path,class: 'btn btn-primary ' %>
+        <%= link_to "注文履歴一覧を見る", admins_homes_top_path(order_sort: 0),class: 'btn btn-primary ' %>
     </div>
 

--- a/app/views/admins/customers/show.html.erb
+++ b/app/views/admins/customers/show.html.erb
@@ -53,6 +53,6 @@
 
     <div class="col-md-10 text-center">
         <%= link_to "編集する", edit_admins_customer_path(@customer), class: 'btn btn-success form' %>
-        <%= link_to "注文履歴一覧を見る", admins_order_path(@customer),class: 'btn btn-primary ' %>
+        <%= link_to "注文履歴一覧を見る", admins_homes_top_path,class: 'btn btn-primary ' %>
     </div>
 

--- a/app/views/admins/homes/top.html.erb
+++ b/app/views/admins/homes/top.html.erb
@@ -28,28 +28,6 @@
 
       <p><%= paginate @orders, class: "justify-content-center" %></p>
 
-      <!--仮オーダー作成フォーム-->
-      <%= form_with model: [:admins, @order], local: true do |f| %>
-        <%= f.label :customer_id,"購入者ID" %>
-        <%= f.text_field :customer_id %>
-        <%= f.label :delivery_zip_code,"郵便番号" %>
-        <%= f.text_field :delivery_zip_code %>
-        <%= f.label :delivery_address,"住所" %>
-        <%= f.text_field :delivery_address %>
-        <%= f.label :delivery_name,"宛名" %>
-        <%= f.text_field :delivery_name %>
-        <%= f.label :total_price,"商品代金" %>
-        <%= f.text_field :total_price %>
-        <%= f.label :shipping_price,"送料" %>
-        <%= f.text_field :shipping_price %>
-        <%= f.label :billing_amount,"総額" %>
-        <%= f.text_field :billing_amount %>
-        <%= f.label :payment_method,"支払い方法" %>
-        <%= f.select :payment_method, Order.payment_methods.keys.to_a %>
-        <%= f.label :order_status,"注文ステータス" %>
-        <%= f.select :order_status, Order.order_statuses.keys.to_a %>
-        <%= f.submit %>
-      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/admins/homes/top.html.erb
+++ b/app/views/admins/homes/top.html.erb
@@ -27,7 +27,7 @@
       </table>
 
       <p><%= paginate @orders, class: "justify-content-center" %></p>
-
+ 
     </div>
   </div>
 </div>

--- a/app/views/admins/orders/show.html.erb
+++ b/app/views/admins/orders/show.html.erb
@@ -5,7 +5,7 @@
       <p>購入者</p>
     </div>
     <div class="col-md-10">
-      <%= link_to "#{@order.customer.last_name} #{@order.customer.first_name}", admins_customer_path(@order) %>
+      <%= link_to "#{@order.customer.last_name} #{@order.customer.first_name}", admins_customer_path(@order.customer) %>
     </div>
   </div>
   <div class="row">
@@ -38,8 +38,8 @@
       <p>注文ステータス</p>
     </div>
     <div class="col-md-10">
-      <%= form_with model: [:admins, @order], local: true do |f| %>
-        <%= f.select :order_status, Order.order_statuses.keys.to_a %>
+      <%= form_with model:[:admins, @order], method: :patch, local: true do |f| %>
+        <%= f.select :order_status, options_for_select(Order.order_statuses, {selected: @order.order_status}) %>
         <%= f.submit "更新", class: "btn btn-sm btn-success" %>
       <% end %>
     </div>
@@ -65,8 +65,8 @@
               <td><%= order_item.purchase_price %></td>
               <td><%= order_item.amount %></td>
               <td><%= (order_item.purchase_price * order_item.amount).to_s(:delimited, delimiter: ',') %></td>
-              <%= form_with model: @order_item, local: true do |f| %>
-                <td><%= f.select :production_statuses, OrderItem.production_statuses, class: "d-block" %></td>
+              <%= form_with url: admins_order_item_path(order_item), method: :patch, local: true do |f| %>
+                <td><%= f.select :production_status, options_for_select(OrderItem.production_statuses, {selected: order_item.production_status}), class: "d-block" %></td>
                 <td><%= f.submit "更新", class: "btn btn-success" %></td>
               <% end %>
             </tr>

--- a/app/views/admins/orders/show.html.erb
+++ b/app/views/admins/orders/show.html.erb
@@ -38,8 +38,8 @@
       <p>注文ステータス</p>
     </div>
     <div class="col-md-10">
-      <%= form_with model:[:admins, @order], method: :patch, local: true do |f| %>
-        <%= f.select :order_status, options_for_select(Order.order_statuses, {selected: @order.order_status}) %>
+      <%= form_with model:[:admins, @order], local: true do |f| %>
+        <%= f.select :order_status, options_for_select(Order.order_statuses.keys, {selected: @order.order_status}) %>
         <%= f.submit "更新", class: "btn btn-sm btn-success" %>
       <% end %>
     </div>
@@ -65,8 +65,8 @@
               <td><%= order_item.purchase_price %></td>
               <td><%= order_item.amount %></td>
               <td><%= (order_item.purchase_price * order_item.amount).to_s(:delimited, delimiter: ',') %></td>
-              <%= form_with url: admins_order_item_path(order_item), method: :patch, local: true do |f| %>
-                <td><%= f.select :production_status, options_for_select(OrderItem.production_statuses, {selected: order_item.production_status}), class: "d-block" %></td>
+              <%= form_with model: [:admins, order_item], method: :patch, local: true do |f| %>
+                <td><%= f.select :production_status, options_for_select(OrderItem.production_statuses.keys, {selected: order_item.production_status}), class: "d-block" %></td>
                 <td><%= f.submit "更新", class: "btn btn-success" %></td>
               <% end %>
             </tr>

--- a/app/views/cart_items/create.html.erb
+++ b/app/views/cart_items/create.html.erb
@@ -1,2 +1,0 @@
-<h1>CartItems#create</h1>
-<p>Find me in app/views/cart_items/create.html.erb</p>

--- a/app/views/cart_items/destroy.html.erb
+++ b/app/views/cart_items/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>CartItems#destroy</h1>
-<p>Find me in app/views/cart_items/destroy.html.erb</p>

--- a/app/views/cart_items/destroy_all.html.erb
+++ b/app/views/cart_items/destroy_all.html.erb
@@ -1,2 +1,0 @@
-<h1>CartItems#destroy_all</h1>
-<p>Find me in app/views/cart_items/destroy_all.html.erb</p>

--- a/app/views/cart_items/update.html.erb
+++ b/app/views/cart_items/update.html.erb
@@ -1,2 +1,0 @@
-<h1>CartItems#update</h1>
-<p>Find me in app/views/cart_items/update.html.erb</p>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -33,7 +33,7 @@
             <%= link_to '会員一覧', admins_customers_path, :style=>"color:black;", class:"btn btn-light" %>
           </li>
           <li>
-            <%= link_to '注文履歴一覧', admins_homes_top_path, :style=>"color:black;", class:"btn btn-light" %>
+            <%= link_to '注文履歴一覧', admins_homes_top_path(order_sort: 0), :style=>"color:black;", class:"btn btn-light" %>
           </li>
           <li>
             <%= link_to 'ジャンル一覧', admins_genres_path, :style=>"color:black;", class:"btn btn-light" %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -33,7 +33,7 @@
             <%= link_to '会員一覧', admins_customers_path, :style=>"color:black;", class:"btn btn-light" %>
           </li>
           <li>
-            <%= link_to '注文履歴一覧', admins_homes_top_path(order_sort: 0), :style=>"color:black;", class:"btn btn-light" %>
+            <%= link_to '注文履歴一覧', admins_homes_top_path, :style=>"color:black;", class:"btn btn-light" %>
           </li>
           <li>
             <%= link_to 'ジャンル一覧', admins_genres_path, :style=>"color:black;", class:"btn btn-light" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
     registrations: 'admins/registrations'
   }
   namespace :admins do
-    # create仮作成
-    resources :orders, only: [:show, :update, :create]
+    resources :orders, only: [:show, :update]
+    resources :order_items, only: [:update]
     resources :customers, only: [:index, :show, :edit, :update]
     resources :items, only: [:index, :show, :new, :create, :edit, :update]
     resources :genres, only: [:index, :create, :edit, :update]
@@ -39,6 +39,6 @@ Rails.application.routes.draw do
   resources :deliveries, only: [:index, :create, :edit, :update, :destroy]
   resources :customers, only: [:show, :edit, :update]
   resources :deliveries, only: [:index, :create, :edit, :update, :destroy]
-  
+
 end
 


### PR DESCRIPTION
headerからの転移とカスタマー詳細からの転移の場合のビューを条件分岐しました。

カスタマー詳細からの転移の際にページリロードで、一覧が消えてしまいますが、エラー表示等はされないので、最低限の状況にはなってます。
修正には時間がかかりそうなので、いったんこれで完成とします。